### PR TITLE
Feature/Preprints Not Building - ember-cli-favicon issues

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -28,7 +28,8 @@ module.exports = function(defaults) {
               importBootstrapCSS: false
           },
           fingerprint: {
-              prepend: ''
+              prepend: '',
+              exclude: ['apple-touch-icon', 'favicon', 'mstile']
           }
   });
 


### PR DESCRIPTION
# Purpose
ember build errors

```
/Users/dawnpattison/ember-lookit-frameplayer/node_modules/ember-cli-favicon/index.js:23
        if (result.favicon_generation_result.result.status === 'error') {
                                            ^

TypeError: Cannot read property 'result' of undefined
```

# Changes 
Add exclude: ['apple-touch-icon', 'favicon', 'mstile'] to fingerprint. credit @cwisecarver 