### PR TITLE
Feature/Add createdOn field to Response Model [LEI-471]

### DIFF
--- a/app/models/response.js
+++ b/app/models/response.js
@@ -8,5 +8,6 @@ export default DS.Model.extend({
     completed: DS.attr('boolean'),
     child: DS.belongsTo('child'),
     study: DS.belongsTo('study'),
-    demographicSnapshot: DS.belongsTo('demographic')
+    demographicSnapshot: DS.belongsTo('demographic'),
+    createdOn: DS.attr('date')
 });


### PR DESCRIPTION
# Ticket 
https://openscience.atlassian.net/browse/LEI-471

# Purpose
currentDaysSessionsCompleted function is not working because it relies on the created_on dates of previous responses.

# Changes
- Add createdOn field to Response Model so it can be used in the currentDaysSessionCompleted method 