### PR TITLE
Feature/Update Bower Registry URL

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "bower_components",
-  "analytics": false
+  "analytics": false,
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
# Purpose

Add registry url to .bowerrc file so it builds correctly. The old bower url won’t work anymore.
Thanks @binoculars 👍 